### PR TITLE
Rule: median past time

### DIFF
--- a/protostar.toml
+++ b/protostar.toml
@@ -1,5 +1,5 @@
 ["protostar.config"]
-protostar_version = "0.2.1"
+protostar_version = "0.2.3"
 
 ["protostar.project"]
 libs_path = "lib"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cairo-lang
-openzeppelin-cairo-contracts
+git+https://github.com/OpenZeppelin/cairo-contracts.git
 marshmallow-dataclass==8.5.3
 black
 pylint

--- a/src/header/rules/median_past_time.cairo
+++ b/src/header/rules/median_past_time.cairo
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: MIT
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.math import assert_lt
+from starkware.cairo.common.math_cmp import is_le
+from starkware.cairo.common.bool import TRUE, FALSE
+
+from header.library import BlockHeader
+
+# ------
+# CONSTANTS
+# ------
+const TIMESTAMP_COUNT = 11
+const TIMESTAMP_MEDIAN_INDEX = 6
+
+# ------
+# STRUCTS
+# ------
+struct Timestamps:
+    member t1 : felt
+    member t2 : felt
+    member t3 : felt
+    member t4 : felt
+    member t5 : felt
+    member t6 : felt
+    member t7 : felt
+    member t8 : felt
+    member t9 : felt
+    member t10 : felt
+    member t11 : felt
+end
+
+# ------
+# STORAGE
+# ------
+@storage_var
+func last_11_timestamps() -> (timestamps : Timestamps):
+end
+
+# ------
+# RULE
+# ------
+func assert_median_past_time{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    header : BlockHeader
+):
+    alloc_locals
+    let (timestamps : Timestamps) = last_11_timestamps.read()
+    let (local timestamp_median) = internal.compute_timestamps_median(timestamps)
+    local block_timestamp = header.time
+
+    with_attr error_message(
+            "[rule] Median Past Time: block timestamp ({block_timestamp}) must be higher than the median ({timestamp_median}) of the previous 11 block timestamps"):
+        assert_lt(timestamp_median, block_timestamp)
+    end
+    return ()
+end
+
+# This function must be called when a block is accepted so that the list of the last 11 timestamps is updated
+func on_block_accepted{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    header : BlockHeader
+):
+    let (timestamps : Timestamps) = last_11_timestamps.read()
+    let new_timestamps : Timestamps = Timestamps(
+        timestamps.t2,
+        timestamps.t3,
+        timestamps.t4,
+        timestamps.t5,
+        timestamps.t6,
+        timestamps.t7,
+        timestamps.t8,
+        timestamps.t9,
+        timestamps.t10,
+        timestamps.t11,
+        header.time,
+    )
+    last_11_timestamps.write(new_timestamps)
+    return ()
+end
+
+# ------
+# INTERNAL
+# ------
+namespace internal:
+    func compute_timestamps_median{range_check_ptr}(timestamps : Timestamps) -> (
+        median_value : felt
+    ):
+        tempvar timestamp_array : felt* = new (
+            timestamps.t1,
+            timestamps.t2,
+            timestamps.t3,
+            timestamps.t4,
+            timestamps.t5,
+            timestamps.t6,
+            timestamps.t7,
+            timestamps.t8,
+            timestamps.t9,
+            timestamps.t10,
+            timestamps.t11)
+
+        let (sorted_timestamp_array : felt*) = sort_unsigned(TIMESTAMP_COUNT, timestamp_array)
+        return (median_value=sorted_timestamp_array[TIMESTAMP_MEDIAN_INDEX])
+    end
+
+    func sort_unsigned{range_check_ptr}(arr_len : felt, arr : felt*) -> (sorted_array : felt*):
+        alloc_locals
+
+        let (local sorted_array : felt*) = alloc()
+        sort_unsigned_loop(arr_len, arr, sorted_array)
+        return (sorted_array)
+    end
+
+    func sort_unsigned_loop{range_check_ptr}(arr_len : felt, arr : felt*, sorted_array : felt*):
+        if arr_len == 0:
+            return ()
+        end
+
+        # find the lowest element out of remaining elements
+        let (lowest_element_index, lowest_element) = internal.find_lowest_element(arr_len, arr)
+
+        # push the lowest element to the sorted array
+        assert sorted_array[0] = lowest_element
+
+        # remove the lowest element from the remaining elements
+        let (arr : felt*) = copy_array_without_index(arr_len, arr, lowest_element_index)
+
+        sort_unsigned_loop(arr_len - 1, arr, sorted_array + 1)
+        return ()
+    end
+
+    func find_lowest_element{range_check_ptr}(arr_len : felt, arr : felt*) -> (
+        lowest_element_index : felt, lowest_element : felt
+    ):
+        return find_lowest_element_loop(0, arr_len, arr, 0)
+    end
+
+    func find_lowest_element_loop{range_check_ptr}(
+        index : felt, arr_len : felt, arr : felt*, lowest_element_index : felt
+    ) -> (lowest_element_index : felt, lowest_element : felt):
+        if index == arr_len:
+            return (
+                lowest_element_index=lowest_element_index, lowest_element=arr[lowest_element_index]
+            )
+        end
+
+        let (is_lower) = is_le(arr[index], arr[lowest_element_index])
+        let new_lowest_element_index = index * is_lower + lowest_element_index * (1 - is_lower)
+
+        return find_lowest_element_loop(index + 1, arr_len, arr, new_lowest_element_index)
+    end
+
+    func copy_array_without_index{range_check_ptr}(
+        arr_len : felt, arr : felt*, removed_index : felt
+    ) -> (new_arr : felt*):
+        alloc_locals
+
+        let (local new_arr : felt*) = alloc()
+        copy_array_without_index_loop(0, arr_len, arr, removed_index, 0, new_arr)
+        return (new_arr)
+    end
+
+    func copy_array_without_index_loop{range_check_ptr}(
+        index : felt,
+        arr_len : felt,
+        arr : felt*,
+        removed_index : felt,
+        new_index : felt,
+        new_arr : felt*,
+    ):
+        if index == arr_len:
+            return ()
+        end
+
+        if index == removed_index:
+            copy_array_without_index_loop(
+                index + 1, arr_len, arr, removed_index, new_index, new_arr
+            )
+            return ()
+        end
+
+        assert new_arr[new_index] = arr[index]
+
+        copy_array_without_index_loop(
+            index + 1, arr_len, arr, removed_index, new_index + 1, new_arr
+        )
+        return ()
+    end
+end

--- a/src/header/rules/test_median_past_time.cairo
+++ b/src/header/rules/test_median_past_time.cairo
@@ -1,0 +1,137 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.alloc import alloc
+
+from header.library import BlockHeader
+from header.rules.median_past_time import (
+    internal,
+    Timestamps,
+    last_11_timestamps,
+    assert_median_past_time,
+    on_block_accepted,
+)
+
+@view
+func test_assert_median_past_time_doesnt_revert_when_timestamp_is_higher_than_median{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+}():
+    # median of timestamps is 8
+    let timestamps : Timestamps = Timestamps(10, 16, 8, 0, 3, 3, 7, 20, 0, 4, 10)
+    last_11_timestamps.write(timestamps)
+
+    tempvar header : BlockHeader = BlockHeader(
+        version=2, previous=new (), merkle_root=new (), time=9, bits=10, nonce=10, data=new ()
+        )
+
+    assert_median_past_time(header)
+
+    return ()
+end
+
+@view
+func test_assert_median_past_time_reverts_when_timestamp_is_lower_than_median{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+}():
+    # median of timestamps is 8
+    let timestamps : Timestamps = Timestamps(10, 16, 8, 0, 3, 3, 7, 20, 0, 4, 10)
+    last_11_timestamps.write(timestamps)
+
+    tempvar header : BlockHeader = BlockHeader(
+        version=2, previous=new (), merkle_root=new (), time=7, bits=10, nonce=10, data=new ()
+        )
+
+    %{ expect_revert(error_message="[rule] Median Past Time: block timestamp (7) must be higher than the median (8) of the previous 11 block timestamps") %}
+    assert_median_past_time(header)
+
+    return ()
+end
+
+@view
+func test_assert_median_past_time_reverts_when_timestamp_equals_median{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+}():
+    # median of timestamps is 8
+    let timestamps : Timestamps = Timestamps(10, 16, 8, 0, 3, 3, 7, 20, 0, 4, 10)
+    last_11_timestamps.write(timestamps)
+
+    tempvar header : BlockHeader = BlockHeader(
+        version=2, previous=new (), merkle_root=new (), time=8, bits=10, nonce=10, data=new ()
+        )
+
+    %{ expect_revert(error_message="[rule] Median Past Time: block timestamp (8) must be higher than the median (8) of the previous 11 block timestamps") %}
+    assert_median_past_time(header)
+
+    return ()
+end
+
+@view
+func test_on_block_accepted{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    # median of timestamps is 8
+    let timestamps : Timestamps = Timestamps(10, 16, 8, 0, 3, 3, 7, 20, 0, 4, 10)
+    last_11_timestamps.write(timestamps)
+
+    tempvar header : BlockHeader = BlockHeader(
+        version=2, previous=new (), merkle_root=new (), time=9, bits=10, nonce=10, data=new ()
+        )
+
+    on_block_accepted(header)
+
+    let (timestamps : Timestamps) = last_11_timestamps.read()
+    assert timestamps = Timestamps(16, 8, 0, 3, 3, 7, 20, 0, 4, 10, 9)
+    return ()
+end
+
+@view
+func test_compute_timestamps_median{range_check_ptr}():
+    let timestamps : Timestamps = Timestamps(10, 16, 8, 0, 3, 3, 7, 20, 0, 4, 10)
+
+    let (median) = internal.compute_timestamps_median(timestamps)
+
+    assert median = 8
+
+    return ()
+end
+
+@view
+func test_find_lowest_element{range_check_ptr}():
+    let (lowest_element_index, lowest_element) = internal.find_lowest_element(4, new (10, 4, 3, 7))
+
+    assert lowest_element_index = 2
+    assert lowest_element = 3
+
+    return ()
+end
+
+@view
+func test_sort_unsigned{range_check_ptr}():
+    let (sorted_array : felt*) = internal.sort_unsigned(4, new (10, 4, 3, 7))
+
+    assert 3 = sorted_array[0]
+    assert 4 = sorted_array[1]
+    assert 7 = sorted_array[2]
+    assert 10 = sorted_array[3]
+
+    return ()
+end
+
+@view
+func test_sort_unsigned_with_equal_values{range_check_ptr}():
+    let (sorted_array : felt*) = internal.sort_unsigned(
+        11, new (10, 16, 8, 0, 3, 3, 7, 20, 0, 4, 10)
+    )
+
+    assert 0 = sorted_array[0]
+    assert 0 = sorted_array[1]
+    assert 3 = sorted_array[2]
+    assert 3 = sorted_array[3]
+    assert 4 = sorted_array[4]
+    assert 7 = sorted_array[5]
+    assert 8 = sorted_array[6]
+    assert 10 = sorted_array[7]
+    assert 10 = sorted_array[8]
+    assert 16 = sorted_array[9]
+    assert 20 = sorted_array[10]
+
+    return ()
+end


### PR DESCRIPTION
Closes #7 

Implements a rule that checks if block timestamp is greater than the median timestamp of previous 11 blocks.

The rule is **not** used for now (I did not add it to the block header verification process) but the idea is to use it this way:
```cairo
func process_header(header):
    ...
    median_past_time.assert_rule(header)
    ...
end

func accept_block(header):
    ...
    median_past_time.on_block_accepted(header)
    ...
end
```

We can already see a potential pattern for rules:
- a namespace with a name that matches the rule (ie. `namespace median_past_time`)
- a function in this namespace called `assert_rule`
- a function in this namespace called `on_block_accepted`

I guess we'll see later if we can decide a common signature for those functions. If this is the case, we'll be able to write something like this:
```cairo
func init():
    ...
    add_rule(median_past_time.assert_rule)
    register_on_block_accepted_callback(median_past_time.on_block_accepted)
    ...
end
```