### PR TITLE
refactor: put decode_target in utils to be used by the upcoming target rule

### DIFF
--- a/src/header/rules/check_pow.cairo
+++ b/src/header/rules/check_pow.cairo
@@ -5,13 +5,9 @@
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.bool import TRUE, FALSE
 from starkware.cairo.common.uint256 import Uint256, uint256_lt
-from starkware.cairo.common.math import split_felt, unsigned_div_rem
-from starkware.cairo.common.pow import pow
-
-from utils.sha256.sha256_contract import compute_sha256
-from utils.common import swap_endianness_64
 
 from header.library import BlockHeader
+from utils.target import decode_target
 
 # ------
 # CONSTANTS
@@ -36,7 +32,7 @@ namespace check_pow:
         alloc_locals
 
         let header_hash = header.hash
-        let (target) = internal.get_target(header.bits)
+        let (target) = decode_target(header.bits)
         let (res) = uint256_lt(header_hash, target)
 
         local target_hi = target.high
@@ -54,19 +50,5 @@ namespace check_pow:
         header : BlockHeader
     ):
         return ()
-    end
-end
-
-# ------
-# INTERNAL
-# ------
-namespace internal:
-    func get_target{range_check_ptr}(bits : felt) -> (res : Uint256):
-        alloc_locals
-        let (exponent, local mantissa) = unsigned_div_rem(bits, 2 ** 24)
-        let (exp) = pow(256, exponent - 3)
-        let tmp = mantissa * exp
-        let res_target = split_felt(tmp)
-        return (Uint256(res_target.low, res_target.high))
     end
 end

--- a/src/header/rules/test_check_pow.cairo
+++ b/src/header/rules/test_check_pow.cairo
@@ -1,13 +1,11 @@
 %lang starknet
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
-from starkware.cairo.common.alloc import alloc
-from starkware.cairo.common.math import split_felt
-from starkware.cairo.common.uint256 import Uint256, uint256_eq
+from starkware.cairo.common.uint256 import Uint256
 from starkware.cairo.common.bool import TRUE
 
 from header.library import BlockHeader
-from header.rules.check_pow import internal, check_pow
+from header.rules.check_pow import check_pow
 
 @view
 func test_check_pow_verifies_genesis{
@@ -25,31 +23,5 @@ func test_check_pow_verifies_genesis{
 
     check_pow.assert_rule(header)
 
-    return ()
-end
-
-@view
-func test_target_genesis{
-    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, bitwise_ptr : BitwiseBuiltin*
-}():
-    alloc_locals
-    let bits = 0x1d00ffff
-    let (local target) = internal.get_target(bits)
-    let (hi, lo) = split_felt(0x00000000ffff0000000000000000000000000000000000000000000000000000)
-    let (is_eq) = uint256_eq(target, Uint256(lo, hi))
-    assert TRUE = is_eq
-    return ()
-end
-
-@view
-func test_target{
-    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, bitwise_ptr : BitwiseBuiltin*
-}():
-    alloc_locals
-    let bits = 0x1729d72d
-    let (local target) = internal.get_target(bits)
-    let (hi, lo) = split_felt(0x00000000000000000029d72d0000000000000000000000000000000000000000)
-    let (is_eq) = uint256_eq(target, Uint256(lo, hi))
-    assert TRUE = is_eq
     return ()
 end

--- a/src/utils/target.cairo
+++ b/src/utils/target.cairo
@@ -1,0 +1,17 @@
+from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.math import unsigned_div_rem, split_felt
+from starkware.cairo.common.pow import pow
+
+func decode_target{range_check_ptr}(bits : felt) -> (res : Uint256):
+    alloc_locals
+    let (exponent, local mantissa) = unsigned_div_rem(bits, 2 ** 24)
+    let (exp) = pow(256, exponent - 3)
+    let tmp = mantissa * exp
+    let res_target = split_felt(tmp)
+    return (Uint256(res_target.low, res_target.high))
+end
+
+func encode_target{range_check_ptr}(val : Uint256) -> (bits : felt):
+    return (0)
+end

--- a/src/utils/test_target.cairo
+++ b/src/utils/test_target.cairo
@@ -1,0 +1,35 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.math import split_felt
+from starkware.cairo.common.uint256 import Uint256, uint256_eq
+from starkware.cairo.common.bool import TRUE
+
+from utils.target import decode_target, encode_target
+
+@view
+func test_target_genesis{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, bitwise_ptr : BitwiseBuiltin*
+}():
+    alloc_locals
+    let bits = 0x1d00ffff
+    let (local target) = decode_target(bits)
+    let (hi, lo) = split_felt(0x00000000ffff0000000000000000000000000000000000000000000000000000)
+    let (is_eq) = uint256_eq(target, Uint256(lo, hi))
+    assert TRUE = is_eq
+    return ()
+end
+
+@view
+func test_target{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, bitwise_ptr : BitwiseBuiltin*
+}():
+    alloc_locals
+    let bits = 0x1729d72d
+    let (local target) = decode_target(bits)
+    let (hi, lo) = split_felt(0x00000000000000000029d72d0000000000000000000000000000000000000000)
+    let (is_eq) = uint256_eq(target, Uint256(lo, hi))
+    assert TRUE = is_eq
+    return ()
+end


### PR DESCRIPTION
This is to prepare the target rule and avoid a too-big POUR