### PR TITLE
Add encode_target implementation

### DIFF
--- a/src/header/library.cairo
+++ b/src/header/library.cairo
@@ -114,8 +114,6 @@ namespace BlockHeaderVerifier:
         let (single_sha) = compute_sha256(data, 80)
         let (double_sha) = compute_sha256(single_sha, 32)
 
-        # %{ print('block hash:', ''.join([f'{memory[ids.double_sha + i]:08x}' for i in range(8)])) %}
-
         let (hash0) = swap_endianness_64(double_sha[6] * 2 ** 32 + double_sha[7], 8)
         let (hash1) = swap_endianness_64(double_sha[4] * 2 ** 32 + double_sha[5], 8)
         let (hash2) = swap_endianness_64(double_sha[2] * 2 ** 32 + double_sha[3], 8)

--- a/src/header/rules/check_pow.cairo
+++ b/src/header/rules/check_pow.cairo
@@ -18,11 +18,10 @@ const TRUNC_MAX_TARGET = 0x00000000FFFF00000000000000000000000000000000000000000
 # ------
 # RULE: Proof Of Work
 # Description: A block is considered valid if the block header hash value is less than the difficulty target
-# Ref:
+# Ref: https://en.bitcoin.it/wiki/Target
 # ------
-
 namespace check_pow:
-    # This function reverts if
+    # This function reverts if the hash of the iput black header is not lower that the block target
     func assert_rule{
         syscall_ptr : felt*,
         pedersen_ptr : HashBuiltin*,

--- a/src/utils/target.cairo
+++ b/src/utils/target.cairo
@@ -2,6 +2,7 @@ from starkware.cairo.common.uint256 import Uint256
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.math import unsigned_div_rem, split_felt
 from starkware.cairo.common.pow import pow
+from starkware.cairo.common.math_cmp import is_le
 
 func decode_target{range_check_ptr}(bits : felt) -> (res : Uint256):
     alloc_locals
@@ -12,6 +13,71 @@ func decode_target{range_check_ptr}(bits : felt) -> (res : Uint256):
     return (Uint256(res_target.low, res_target.high))
 end
 
-func encode_target{range_check_ptr}(val : Uint256) -> (bits : felt):
-    return (0)
+func encode_target{range_check_ptr}(target : Uint256) -> (bits):
+    alloc_locals
+    local bytes : felt*
+    local size
+
+    let (size_lo, bytes_lo) = get_bytes_128(target.low)
+    assert bytes = bytes_lo
+
+    if target.high == 0:
+        assert size = size_lo
+        tempvar range_check_ptr = range_check_ptr
+    else:
+        pad(16, size_lo, bytes_lo)
+        let (size_hi) = _get_bytes_128(target.high, bytes_lo + 16, 16)
+        assert size = size_hi
+        tempvar range_check_ptr = range_check_ptr
+    end
+    tempvar range_check_ptr = range_check_ptr
+
+    let (local compact) = get_truncated_target(3, size, bytes, 0)
+
+    let (is_neg) = is_le(0x00800000, compact)
+    if is_neg == 1:
+        let (adj_compact, _) = unsigned_div_rem(compact, 256)
+        return (adj_compact + (size + 1) * 2 ** 24)
+    else:
+        return (compact + size * 2 ** 24)
+    end
+end
+
+func pad(pad_to : felt, len : felt, bytes : felt*):
+    if pad_to == 0:
+        return ()
+    end
+
+    if len == 0:
+        assert [bytes] = 0
+        return pad(pad_to - 1, 0, bytes + 1)
+    end
+    return pad(pad_to - 1, len - 1, bytes + 1)
+end
+
+func _get_bytes_128{range_check_ptr : felt}(x, bytes : felt*, bytes_len : felt) -> (
+    bytes_len : felt
+):
+    let (q, r) = unsigned_div_rem(x, 256)
+    [bytes] = r
+    if q == 0:
+        return (bytes_len + 1)
+    else:
+        return _get_bytes_128(q, bytes + 1, bytes_len + 1)
+    end
+end
+
+func get_bytes_128{range_check_ptr}(x) -> (bytes_len, bytes : felt*):
+    alloc_locals
+    let (local bytes : felt*) = alloc()
+    let (size) = _get_bytes_128(x, bytes, 0)
+    return (size, bytes)
+end
+
+func get_truncated_target(size, bytes_len, bytes : felt*, acc : felt) -> (res):
+    if bytes_len * size == 0:
+        return (acc)
+    end
+
+    return get_truncated_target(size - 1, bytes_len - 1, bytes, acc * 256 + bytes[bytes_len - 1])
 end

--- a/src/utils/test_target.cairo
+++ b/src/utils/test_target.cairo
@@ -6,7 +6,8 @@ from starkware.cairo.common.math import split_felt
 from starkware.cairo.common.uint256 import Uint256, uint256_eq
 from starkware.cairo.common.bool import TRUE
 
-from utils.target import decode_target, encode_target
+from utils.target import decode_target, encode_target, pad, get_bytes_128, _get_bytes_128
+from utils.array import arr_eq
 
 @view
 func test_target_genesis{
@@ -31,5 +32,122 @@ func test_target{
     let (hi, lo) = split_felt(0x00000000000000000029d72d0000000000000000000000000000000000000000)
     let (is_eq) = uint256_eq(target, Uint256(lo, hi))
     assert TRUE = is_eq
+    return ()
+end
+
+@view
+func test_pad{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    alloc_locals
+    let (local arr) = alloc()
+    assert arr[0] = 1
+    assert arr[1] = 2
+    assert arr[2] = 3
+    assert arr[3] = 4
+    pad(6, 4, arr)
+    local res : felt* = new (1, 2, 3, 4, 0, 0)
+    arr_eq(arr, 6, res, 6)
+    return ()
+end
+
+@view
+func test_get_bytes_128{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    alloc_locals
+    let value = 0x123456789
+    let (size, bytes) = get_bytes_128(value)
+    local res : felt* = new (89, 67, 45, 23, 01)
+    arr_eq(bytes, size, res, size)
+
+    let value = 0
+    let (size, bytes) = get_bytes_128(value)
+    local res : felt* = new (0)
+    arr_eq(bytes, size, res, size)
+    let value = 1
+    let (size, bytes) = get_bytes_128(value)
+    local res : felt* = new (1)
+    arr_eq(bytes, size, res, size)
+
+    let (local size, local bytes) = get_bytes_128(0x0004444000077770000)
+    local res : felt* = new (44, 44, 00, 00, 77, 77, 00, 00)
+    arr_eq(bytes, size, res, size)
+
+    let (local size, local bytes) = get_bytes_128(2 ** 128 - 1)
+    local res : felt* = new (255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255)
+    arr_eq(bytes, size, res, size)
+
+    let (size) = _get_bytes_128(0x0004444000077770000, bytes + size, size)
+    local res : felt* = new (255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 44, 44, 00, 00, 77, 77, 00, 00)
+    arr_eq(bytes, size, res, size)
+
+    return ()
+end
+
+func felt_to_uint256{range_check_ptr}(x) -> (res : Uint256):
+    let (hi, lo) = split_felt(x)
+    return (Uint256(lo, hi))
+end
+
+struct Target_test_vector:
+    member target : Uint256
+    member bits : felt
+end
+
+func rec_test_targets{range_check_ptr}(len, test_data_ptr : Target_test_vector*):
+    if len == 0:
+        return ()
+    end
+
+    let (bits_computed) = encode_target(test_data_ptr.target)
+    assert test_data_ptr.bits = bits_computed
+    return rec_test_targets(len - 1, test_data_ptr + Target_test_vector.SIZE)
+end
+
+@view
+func test_encode_target{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    alloc_locals
+    let (local tests : Target_test_vector*) = alloc()
+
+    let (target) = felt_to_uint256(
+        0x00000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+    )
+    assert tests[0] = Target_test_vector(target, 0x1d00ffff)
+    let (target) = felt_to_uint256(
+        0x00000000FFFF0000000000000000000000000000000000000000000000000000
+    )
+    assert tests[1] = Target_test_vector(target, 0x1d00ffff)
+    let (target) = felt_to_uint256(
+        0x00000000d86a0000000000000000000000000000000000000000000000000000
+    )
+    assert tests[2] = Target_test_vector(target, 0x1d00d86a)
+    let (target) = felt_to_uint256(
+        0x00000000be710000000000000000000000000000000000000000000000000000
+    )
+    assert tests[3] = Target_test_vector(target, 0x1d00be71)
+    let (target) = felt_to_uint256(
+        0x0000000065465700000000000000000000000000000000000000000000000000
+    )
+    assert tests[4] = Target_test_vector(target, 0x1c654657)
+    let (target) = felt_to_uint256(
+        0x00000000000e7256000000000000000000000000000000000000000000000000
+    )
+    assert tests[5] = Target_test_vector(target, 0x1b0e7256)
+    let (target) = felt_to_uint256(
+        0x0000000000000abbcf0000000000000000000000000000000000000000000000
+    )
+    assert tests[6] = Target_test_vector(target, 0x1a0abbcf)
+    let (target) = felt_to_uint256(
+        0x00000000000004fa620000000000000000000000000000000000000000000000
+    )
+    assert tests[7] = Target_test_vector(target, 0x1a04fa62)
+    let (target) = felt_to_uint256(
+        0x000000000000000000ff18000000000000000000000000000000000000000000
+    )
+    assert tests[8] = Target_test_vector(target, 0x1800ff18)
+    let (target) = felt_to_uint256(0xc0de000000)
+    assert tests[9] = Target_test_vector(target, 0x0600c0de)
+    let (target) = felt_to_uint256(0x1234560000)
+    assert tests[10] = Target_test_vector(target, 0x05123456)
+
+    rec_test_targets(11, tests)
+
     return ()
 end


### PR DESCRIPTION
## Description
  Implement a function to encode the block header target from a `Uint256` to its compact `bits` representation.