### PR TITLE
Test/block header verifier

### DIFF
--- a/docs/bitcoin/block_header_validation_rules.md
+++ b/docs/bitcoin/block_header_validation_rules.md
@@ -2,7 +2,7 @@
 
 See <https://github.com/bitcoin/bitcoin/blob/master/src/validation.cpp#L3577>
 
-Note: the genesis block is treated specificaly: if the block hash is equal to the hash of the genesis block, then all checks are bypassed.
+Note: the genesis block is treated separately: if the current block hash is equal to the genesis block hash, then all checks are bypassed.
 
 This documentation keeps the order of checks as they are done in bitcoin core.
 
@@ -28,7 +28,7 @@ If it is known, there is nothing more to do for us.
 
 [Issue](https://github.com/bitcoin-stark/khepri-starknet/issues/13)
 
-Check proof of work matches claimed amount. In other words, check that the proof of work is lower than (or equal) the target which is specified in the field `bits` of the header.
+Check proof of work matches claimed amount. In other words, check that the proof of work is lower than (or equal) the target which is specified in the header `bits` field.
 
 ## Check previous block
 

--- a/scripts/utils/header_to_cairo.py
+++ b/scripts/utils/header_to_cairo.py
@@ -1,0 +1,39 @@
+import json
+
+def hash_to_Uint256_cairo(hash_hex_str):
+    low = hash_hex_str[32:]
+    high = hash_hex_str[:32]
+    return f"Uint256(low=0x{low}, high=0x{high})"
+    
+def header_to_cairo(block_json):
+    prev_block = block_json["previousblockhash"] if "previousblockhash" in block_json else "0"*64
+    hash = block_json["hash"] if "hash" in block_json else "0"*64
+    merkle_root = block_json["merkleroot"] if "merkleroot" in block_json else "0"*64
+    res = f"""\
+BlockHeader(
+    version= {block_json['version']}, 
+    prev_block={hash_to_Uint256_cairo(prev_block)},
+    merkle_root={hash_to_Uint256_cairo(merkle_root)},
+    timestamp={block_json['time']},
+    bits=0x{block_json['bits']},
+    nonce={block_json['nonce']},
+    hash={hash_to_Uint256_cairo(hash)},
+    )\
+"""
+    return res
+
+
+def main():
+    import sys
+    input_name = sys.argv[1] 
+
+    if input_name is None: return
+
+    with open(input_name) as block_file:
+        block = json.load(block_file)
+    
+    res = header_to_cairo(block)
+    print(f"let header: BlockHeader = {res}")
+
+if __name__ == "__main__":
+    main()

--- a/src/header/rules/check_pow.cairo
+++ b/src/header/rules/check_pow.cairo
@@ -21,7 +21,7 @@ const TRUNC_MAX_TARGET = 0x00000000FFFF00000000000000000000000000000000000000000
 # Ref: https://en.bitcoin.it/wiki/Target
 # ------
 namespace check_pow:
-    # This function reverts if the hash of the iput black header is not lower that the block target
+    # This function reverts if the hash of the input block header is greater than the block target
     func assert_rule{
         syscall_ptr : felt*,
         pedersen_ptr : HashBuiltin*,

--- a/src/header/test_block_header_verifier.cairo
+++ b/src/header/test_block_header_verifier.cairo
@@ -1,0 +1,34 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from header.model import BlockHeaderValidationContext, BlockHeader
+from header.library import BlockHeaderVerifier
+from header.test_utils import test_utils
+
+@view
+func test_process_block{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, bitwise_ptr : BitwiseBuiltin*
+}():
+    alloc_locals
+
+    let (header0) = test_utils.load_header_from_json('./resources/blocks/block0.json')
+
+    let header1 : BlockHeader = BlockHeader(
+        version=1,
+        prev_block=Uint256(low=0x4ff763ae46a2a6c172b3f1b60a8ce26f, high=0x000000000019d6689c085ae165831e93),
+        merkle_root=Uint256(low=0x6714ee1f0e68bebb44a74b1efd512098, high=0x0e3e2357e806b6cdb1f70b54c3a3a17b),
+        timestamp=1231469665,
+        bits=0x1d00ffff,
+        nonce=2573394689,
+        hash=Uint256(low=0x75428afc90947ee320161bbf18eb6048, high=0x00000000839a8e6886ab5951d76f4114),
+    )
+    let ctx = BlockHeaderValidationContext(
+        height=1, block_header=header1, previous_block_header=header0
+    )
+
+    BlockHeaderVerifier.process_header(ctx)
+
+    return ()
+end

--- a/src/header/test_utils.cairo
+++ b/src/header/test_utils.cairo
@@ -1,5 +1,6 @@
 %lang starknet
 
+from starkware.cairo.common.uint256 import Uint256
 from header.model import BlockHeader, BlockHeaderValidationContext
 
 namespace test_utils:
@@ -7,5 +8,61 @@ namespace test_utils:
         tempvar ctx : BlockHeaderValidationContext = BlockHeaderValidationContext(
             height=0, block_header=header, previous_block_header=header)
         return (ctx)
+    end
+
+    func print_block_header(x : BlockHeader):
+        %{
+            x = ids.x
+            print(f'version: {x.version:08x}')
+            print(f'prev_block: {x.prev_block.high:032x}{x.prev_block.low:032x}')
+            print(f'merkle_root: {x.merkle_root.high:032x}{x.merkle_root.low:032x}')
+            print(f'timestamp: {x.timestamp}')
+            print(f'bits: {x.bits:08x}')
+            print(f'nonce: {x.nonce:08x}')
+            print(f'hash: {x.hash.high:032x}{x.hash.low:032x}')
+        %}
+        return ()
+    end
+
+    func genesis_block_header() -> (header : BlockHeader):
+        let (header : BlockHeader) = BlockHeader(
+            version=1,
+            prev_block=Uint256(0, 0),
+            merkle_root=Uint256(0x618f76673e2cc77ab2127b7afdeda33b, 0x4a5e1e4baab89f3a32518a88c31bc87f),
+            timestamp=1231006505,
+            bits=0x1d00ffff,
+            nonce=0x7c2bac1d,
+            hash=Uint256(0x4ff763ae46a2a6c172b3f1b60a8ce26f, 0x000000000019d6689c085ae165831e93),
+        )
+        return (header=header)
+    end
+
+    func load_header_from_json(file_name : felt) -> (header : BlockHeader):
+        alloc_locals
+        local header : BlockHeader
+        %{
+            import json
+            f_name_int = int(ids.file_name)
+            file_name = f_name_int.to_bytes((f_name_int.bit_length() + 7 ) // 8, 'big').decode()
+            with open(file_name, 'r') as f:
+                data = json.load(f)
+
+            prev_block = data['previousblockhash'] if 'previousblockhash' in data else "0"*64
+            merkle_root = data['merkleroot']
+            hash = data['hash']
+
+            ids.header.version = data['version']
+            ids.header.prev_block.low = int(prev_block[32:], 16)
+            ids.header.prev_block.high = int(prev_block[:32], 16)
+            ids.header.merkle_root.low = int(merkle_root[32:], 16)
+            ids.header.merkle_root.high = int(merkle_root[:32], 16)
+
+            ids.header.timestamp = data['version']
+            ids.header.bits = int(data['bits'], 16)
+            ids.header.nonce = data['nonce']
+            ids.header.hash.low = int(hash[32:], 16)
+            ids.header.hash.high = int(hash[:32], 16)
+        %}
+        return (header)
     end
 end


### PR DESCRIPTION
Closes #23 

- Added a python script that takes the path to a JSON block header file and spits a Cairo encoded BlockHeader
- Added a Cairo test helper function that directly loads a block header JSON file via a hint.
- Added a test for process_block