### PR TITLE
👷 add protostar version

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,7 +13,7 @@ jobs:
           cache: "pip"
       - name: Install dependencies
         run: |
-          pip install cairo-lang
+          pip install cairo-lang==0.9.1
       - name: Check files formatting
         run: cairo-format -c src/**/*.cairo
   python:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install protostar
         run: |
-          curl -L https://raw.githubusercontent.com/software-mansion/protostar/master/install.sh | bash -- -v 0.3.2
+          curl -L https://raw.githubusercontent.com/software-mansion/protostar/master/install.sh | bash -s -- -v 0.3.2
       - name: Update env variables
         run: |
           source /home/runner/.bashrc | bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install protostar
         run: |
-          curl -L https://raw.githubusercontent.com/software-mansion/protostar/master/install.sh | bash
+          curl -L https://raw.githubusercontent.com/software-mansion/protostar/master/install.sh | bash -- -v 0.3.2
       - name: Update env variables
         run: |
           source /home/runner/.bashrc | bash


### PR DESCRIPTION
Request from @abdelhamidbakhta, I added the protostar version.

An improvement could be to handle this version in github secrets to manage it easier.

Note: protostar [0.3.3](https://github.com/software-mansion/protostar/releases/tag/v0.3.3) tag has been released.